### PR TITLE
Fix an issue where Link will end up in Endless loop

### DIFF
--- a/src/Slug.php
+++ b/src/Slug.php
@@ -218,9 +218,9 @@ class Slug extends DataExtension
         $link = null;
         $owner = $this->getOwner();
         $action = ($action) ? Controller::join_links($owner->URLSlug, $action) : $owner->URLSlug;
-        
+
         $relationName = $this->relationName;
-        if ($relationName && ($parent = $owner->$relationName()) && $parent->hasMethod('Link')) {
+        if ($relationName && ($parent = $owner->$relationName()) && $parent->exists() && $parent->hasMethod('Link')) {
             $link = $parent->Link($action);
         } elseif (Controller::has_curr()) {
             // Quite the assumption, but sufficient in most cases.


### PR DESCRIPTION
## Problem

Using `Link()` end up with an endless loop

Found out that `($parent = $owner->$relationName())` will also return `true` as it will still returns a DataObject but just an empty DO.

## The fix

Add `$parent->exists()` to make sure that this is a valid object and the parent does exists.